### PR TITLE
Update sbt and added support for 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,15 @@
-val appName = "emailaddress"
 
-lazy val emailaddress = Project(appName, file("."))
-  .enablePlugins(/*SbtAutoBuildPlugin, */SbtGitVersioning, SbtArtifactory)
-  .settings(majorVersion := 3)
-  .settings(makePublicallyAvailableOnBintray := true)
+lazy val scala213 = "2.13.5"
+lazy val scala212 = "2.12.13"
+
+lazy val supportedScalaVersions = List(scala213, scala212)
+
+ThisBuild / scalaVersion := scala213
+
+lazy val emailaddress = (project in file("."))
   .settings(
+    name := "emailaddress",
+    crossScalaVersions := supportedScalaVersions,
     scalacOptions ++= Seq(
       "-feature",
       "-language:implicitConversions"
@@ -17,6 +22,3 @@ lazy val emailaddress = Project(appName, file("."))
       "org.scalatestplus" %% "scalacheck-1-15" % "3.2.7.0" % "test"
     )
   )
-
-scalaVersion := "2.13.5"
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,2 @@
-resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-
-//addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.15.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.19.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.20.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "3.1.0"


### PR DESCRIPTION
- Remove Bintray SBT plugins
- Cross build releases for Scala 2.13.5 and 2.12.13
- Temporary version.sbt set to build version to 3.1.0
